### PR TITLE
Fix build (std::isnan reference)

### DIFF
--- a/jack_volume.cpp
+++ b/jack_volume.cpp
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <cstring>
 #include <csignal>
+#include <cmath>
 #include <string>
 #include <stdexcept>
 #include <iostream>
@@ -160,7 +161,7 @@ public:
 		if (index < 0) {
 			return;
 		}
-		JV_ASSERT(!isnan(new_gain_lin), "new_gain_lin is not a number");
+		JV_ASSERT(!std::isnan(new_gain_lin), "new_gain_lin is not a number");
 		JV_ASSERT(index < (int32_t)channels_gain.size(), "channels_gain: index out of bounds: size=" + std::to_string(channels_gain.size()) + " index=" + std::to_string(index));
 		new_gain_lin = MIN(new_gain_lin, 10.0);
 		new_gain_lin = MAX(new_gain_lin, 0.0);


### PR DESCRIPTION
Build fails with
<pre>
jack_volume.cpp: In member function ‘void jack_volume::channel_lin(int32_t, float)’:
jack_volume.cpp:164:14: error: ‘isnan’ was not declared in this scope
   JV_ASSERT(!isnan(new_gain_lin), "new_gain_lin is not a number");
              ^~~~~
</pre>